### PR TITLE
Add uglify to dist grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,14 +71,20 @@ module.exports = function (grunt) {
                     spawn: false
                 }
             }
-        }
+        },
+        uglify: {
+            dist: {
+                src: "dist/elq.js",
+                dest: "dist/elq.min.js"
+            }
+        },
     };
 
     grunt.initConfig(config);
 
     grunt.registerTask("build:dev", ["browserify:dev"]);
     grunt.registerTask("build:test", ["browserify:test"]);
-    grunt.registerTask("build:dist", ["browserify:dist"]);
+    grunt.registerTask("build:dist", ["browserify:dist", "uglify:dist"]);
 
     grunt.registerTask("build", ["build:dev", "build:test"]);
     grunt.registerTask("dist", ["build:dist"]);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "grunt-banner": "^0.3.1",
     "grunt-browserify": "^3.3.0",
     "grunt-contrib-jshint": "^0.11.0",
+    "grunt-contrib-uglify": "^0.11.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-jscs": "^1.2.0",
     "grunt-karma": "^0.10.1",


### PR DESCRIPTION
I added a uglify step to the dist task so a min file is generated. It can be useful for people that are not using a module loader and are just concating vendor pre minified files in their projects