### PR TITLE
Add general support for breakpoints of different types

### DIFF
--- a/src/breakpoint-state-calculator_test.js
+++ b/src/breakpoint-state-calculator_test.js
@@ -6,17 +6,21 @@ var BreakpointStateCalculator = require("./breakpoint-state-calculator.js");
 
 var styleResolver = {
     getComputedStyle: function (element) {
+        if (element.tagName === "HTML") {
+            return {
+                fontSize: "22px"
+            };
+        }
         return element.style;
     }
 };
 
 describe("BreakpointStateCalculator", function () {
     describe("getBreakpointStates", function () {
-        it("should calculate breakpoint states correctly", function () {
+        it("should calculate breakpoint states correctly with pixelValue", function () {
             var breakpointStateCalculator = BreakpointStateCalculator({
                 styleResolver: styleResolver
             });
-
             var breakpoints = [
                 {
                     dimension: "width",
@@ -56,6 +60,87 @@ describe("BreakpointStateCalculator", function () {
                 over: false,
                 under: true,
                 breakpoint: breakpoints[2]
+            });
+        });
+
+        it("should calculate breakpoint states correctly for different types", function () {
+            var breakpointStateCalculator = BreakpointStateCalculator({
+                styleResolver: styleResolver
+            });
+
+            var breakpoints = [
+                {
+                    dimension: "width",
+                    value: 200,
+                    type: "px"
+                },
+                {
+                    dimension: "width",
+                    value: 400,
+                    type: "px"
+                },
+                {
+                    dimension: "width",
+                    pixelValue: 16 * 15,
+                    type: "em"
+                },
+                {
+                    dimension: "width",
+                    pixelValue: 16 * 30,
+                    type: "em"
+                },
+                {
+                    dimension: "width",
+                    pixelValue: 22 * 10,
+                    type: "rem"
+                },
+                {
+                    dimension: "width",
+                    pixelValue: 22 * 20,
+                    type: "rem"
+                }
+            ];
+
+            var element = {
+                style: {
+                    width: "300px",
+                    height: "0px",
+                    fontSize: "16px"
+                }
+            };
+
+            var breakpointStates = breakpointStateCalculator.getBreakpointStates(element, breakpoints);
+
+            expect(breakpointStates.width.length).toEqual(6);
+            expect(breakpointStates.width[0]).toEqual({
+                over: true,
+                under: false,
+                breakpoint: breakpoints[0]
+            });
+            expect(breakpointStates.width[1]).toEqual({
+                over: false,
+                under: true,
+                breakpoint: breakpoints[1]
+            });
+            expect(breakpointStates.width[2]).toEqual({
+                over: true,
+                under: false,
+                breakpoint: breakpoints[2]
+            });
+            expect(breakpointStates.width[3]).toEqual({
+                over: false,
+                under: true,
+                breakpoint: breakpoints[3]
+            });
+            expect(breakpointStates.width[4]).toEqual({
+                over: true,
+                under: false,
+                breakpoint: breakpoints[4]
+            });
+            expect(breakpointStates.width[5]).toEqual({
+                over: false,
+                under: true,
+                breakpoint: breakpoints[5]
             });
         });
     });

--- a/src/plugin/elq-breakpoints/breakpoint-parser.js
+++ b/src/plugin/elq-breakpoints/breakpoint-parser.js
@@ -23,38 +23,6 @@ module.exports = function BreakpointParser(options) {
 
     function parseBreakpoints(element) {
         function getBreakpoints(element, dimension) {
-            function getElementFontSizeInPixels(element) {
-                return parseFloat(styleResolver.getComputedStyle(element).fontSize.replace("px", ""));
-            }
-
-            var breakpointPixelValueConverters = {};
-
-            breakpointPixelValueConverters[BP_UNITS.PX] = function (value) {
-                return value;
-            };
-
-            var cachedRootFontSize; // to avoid unnecessarily asking the DOM for the font-size multiple times for the same element.
-            breakpointPixelValueConverters[BP_UNITS.REM] = function (value) {
-                function getRootElementFontSize() {
-                    if (!cachedRootFontSize) {
-                        cachedRootFontSize = getElementFontSizeInPixels(document.documentElement);
-                    }
-                    return cachedRootFontSize;
-                }
-                return value * getRootElementFontSize();
-            };
-
-            var cachedElementFontSize; // to avoid unnecessarily asking the DOM for the font-size multiple times for the same element.
-            breakpointPixelValueConverters[BP_UNITS.EM] = function (value) {
-                function getElementFontSize() {
-                    if (!cachedElementFontSize) {
-                        cachedElementFontSize = getElementFontSizeInPixels(element);
-                    }
-                    return cachedElementFontSize;
-                }
-                return value * getElementFontSize();
-            };
-
             function getFromMainAttr(element, dimension) {
                 var breakpoints = elementUtils.getAttribute(element, "elq-breakpoints-" + dimension + "s");
 
@@ -80,11 +48,9 @@ module.exports = function BreakpointParser(options) {
                     }
 
                     var value = parseFloat(valueMatch[0]);
-                    var valuePx = breakpointPixelValueConverters[unit](value);
 
                     return {
                         dimension: dimension,
-                        pixelValue: valuePx,
                         value: value,
                         type: unit
                     };

--- a/src/plugin/elq-breakpoints/breakpoint-parser_test.js
+++ b/src/plugin/elq-breakpoints/breakpoint-parser_test.js
@@ -17,12 +17,6 @@ function mockElement(elementData) {
 
 var styleResolver = {
     getComputedStyle: function (element) {
-        if (element.tagName === "HTML") {
-            return {
-                fontSize: "22px"
-            };
-        }
-
         return element.style;
     }
 };
@@ -59,12 +53,10 @@ describe("BreakpointParser", function () {
             expect(breakpoints[0].dimension).toEqual("width");
             expect(breakpoints[0].value).toEqual(500);
             expect(breakpoints[0].type).toEqual("px");
-            expect(breakpoints[0].pixelValue).toEqual(500);
 
             expect(breakpoints[1].dimension).toEqual("width");
             expect(breakpoints[1].value).toEqual(300);
             expect(breakpoints[1].type).toEqual("px");
-            expect(breakpoints[1].pixelValue).toEqual(300);
         });
 
         it("should parse different types of breakpoints", function () {
@@ -89,17 +81,14 @@ describe("BreakpointParser", function () {
             expect(breakpoints[0].dimension).toEqual("width");
             expect(breakpoints[0].value).toEqual(500);
             expect(breakpoints[0].type).toEqual("px");
-            expect(breakpoints[0].pixelValue).toEqual(500);
 
             expect(breakpoints[1].dimension).toEqual("width");
             expect(breakpoints[1].value).toEqual(10);
             expect(breakpoints[1].type).toEqual("rem");
-            expect(breakpoints[1].pixelValue).toEqual(10 * 22);
 
             expect(breakpoints[2].dimension).toEqual("width");
             expect(breakpoints[2].value).toEqual(20);
             expect(breakpoints[2].type).toEqual("em");
-            expect(breakpoints[2].pixelValue).toEqual(20 * 16);
         });
 
         it("should allow unit to be left out and then use defaultUnit", function () {
@@ -125,12 +114,10 @@ describe("BreakpointParser", function () {
             expect(breakpoints[0].dimension).toEqual("width");
             expect(breakpoints[0].value).toEqual(10);
             expect(breakpoints[0].type).toEqual("em");
-            expect(breakpoints[0].pixelValue).toEqual(10 * 16);
 
             expect(breakpoints[1].dimension).toEqual("width");
             expect(breakpoints[1].value).toEqual(30);
             expect(breakpoints[1].type).toEqual("px");
-            expect(breakpoints[1].pixelValue).toEqual(30);
         });
     });
 });


### PR DESCRIPTION
The solution proposed in #46 seems like a pretty big change, suitable maybe for a 2.0 version?
So what do you think about just moving the code that converts different types into the calculator until that is separated into a plugin.